### PR TITLE
Add verify command

### DIFF
--- a/carthage-verify
+++ b/carthage-verify
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# This script verifies that the commitish values in the Cartfile.resolved are in
+# sync with the commitish values in the Carthage/Build/*.version files.
+#
+# Usage:
+#   cd ProjectFolder && /path/to/carthage-verify
+
+sed -E 's/(github|git|binary) \"([^\"]+)\" \"([^\"]+)\"/\2 \3/g' Cartfile.resolved | while read line
+do
+    read -a array <<< "$line"
+
+    # Handles:
+    # - ReactiveCocoa/ReactiveSwift > ReactiveSwift
+    # - https://github.com/Carthage/Carthage.git > Carthage
+    # - https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json > Mapbox-iOS-SDK
+    dependency=`basename ${array[0]} | awk -F'.' '{ print $1 }'`
+
+    resolved_commitish=${array[1]}
+
+    echo -e "Cartfile.resolved[$dependency] at $resolved_commitish"
+
+    version_file="Carthage/Build/.$dependency.version"
+
+    if [ ! -f "$version_file" ]
+    then
+        echo -e "No version file found for $dependency at $version_file, skipping."
+        echo
+        continue
+    fi
+
+    version_file_commitish=`grep -o '"commitish".*"' "$version_file" | awk -F'"' '{ print $4 }'`
+
+    echo -e "$version_file at $version_file_commitish"
+
+    if [ "$resolved_commitish" != "$version_file_commitish" ]
+    then
+        echo
+        echo -e "$dependency commitish ($version_file_commitish) does not match resolved commitish ($resolved_commitish)"
+        exit 1
+    fi
+
+    echo
+done


### PR DESCRIPTION
This script verifies that the commitish values in the Cartfile.resolved are in sync with the commitish values in the Carthage/Build/*.version files.

Ref https://github.com/Carthage/Carthage/issues/1839