### PR TITLE
Build reverse symlink

### DIFF
--- a/carthage-developer-checkouts
+++ b/carthage-developer-checkouts
@@ -9,6 +9,7 @@
 
 mkdir -p "Carthage/Checkouts/"
 
+project_dir=$PWD
 parent_dir=$(dirname "$PWD")
 
 sed -E 's/(github|git) \"[^\/]+\/([^\"]+)\" \"([^\"]+)\"/\2 \3/g' Cartfile.resolved | while read line
@@ -40,6 +41,11 @@ do
         # TODO: Update submodules
 
         popd >/dev/null
+
+		echo -e "\tSymlinking $dependency/Carthage/Build -> $project_dir/Carthage/Build"
+		mkdir -p "$dependency_dir/Carthage" || exit $?
+		rm -rf "$dependency_dir/Carthage/Build" || exit $?
+		ln -s "$project_dir/Carthage/Build" "$dependency_dir/Carthage/Build" || exit $?
 
         echo -e "\tSymlinking $checkout_dir -> $dependency_dir"
         rm -rf "$checkout_dir" || exit $?

--- a/carthage-developer-checkouts
+++ b/carthage-developer-checkouts
@@ -12,7 +12,7 @@ mkdir -p "Carthage/Checkouts/"
 project_dir=$PWD
 parent_dir=$(dirname "$PWD")
 
-sed -E 's/(github|git) \"[^\/]+\/([^\"]+)\" \"([^\"]+)\"/\2 \3/g' Cartfile.resolved | while read line
+sed -E 's/(github|git) \".+\/([^\"]+)\" \"([^\"]+)\"/\2 \3/g' Cartfile.resolved | while read line
 do
     read -a array <<< "$line"
 

--- a/carthage-developer-checkouts
+++ b/carthage-developer-checkouts
@@ -12,12 +12,19 @@ mkdir -p "Carthage/Checkouts/"
 project_dir=$PWD
 parent_dir=$(dirname "$PWD")
 
-sed -E 's/(github|git) \".+\/([^\"]+)\" \"([^\"]+)\"/\2 \3/g' Cartfile.resolved | while read line
+sed -E 's/(github|git|binary) \"([^\"]+)\" \"([^\"]+)\"/\2 \3/g' Cartfile.resolved | while read line
 do
     read -a array <<< "$line"
 
-    dependency=${array[0]}
+    # Handles:
+    # - ReactiveCocoa/ReactiveSwift > ReactiveSwift
+    # - https://github.com/Carthage/Carthage.git > Carthage
+    # - https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json > Mapbox-iOS-SDK
+    dependency=`basename ${array[0]} | awk -F'.' '{ print $1 }'`
+
     version=${array[1]}
+
+    echo -e "Cartfile.resolved[$dependency] at $version"
 
     dependency_dir="$parent_dir/$dependency"
     checkout_dir="Carthage/Checkouts/$dependency"

--- a/carthage-developer-checkouts
+++ b/carthage-developer-checkouts
@@ -42,10 +42,10 @@ do
 
         popd >/dev/null
 
-		echo -e "\tSymlinking $dependency/Carthage/Build -> $project_dir/Carthage/Build"
-		mkdir -p "$dependency_dir/Carthage" || exit $?
-		rm -rf "$dependency_dir/Carthage/Build" || exit $?
-		ln -s "$project_dir/Carthage/Build" "$dependency_dir/Carthage/Build" || exit $?
+        echo -e "\tSymlinking $dependency/Carthage/Build -> $project_dir/Carthage/Build"
+        mkdir -p "$dependency_dir/Carthage" || exit $?
+        rm -rf "$dependency_dir/Carthage/Build" || exit $?
+        ln -s "$project_dir/Carthage/Build" "$dependency_dir/Carthage/Build" || exit $?
 
         echo -e "\tSymlinking $checkout_dir -> $dependency_dir"
         rm -rf "$checkout_dir" || exit $?


### PR DESCRIPTION
Symlink dependency Carthage/Build folder back to parent Carthage/Build so that parent directory can link with latest binary.

Also fixed an issue when parsing Cartfile.resolved file containing fully qualified urls such as
git "ssh://user@foo.com/path/bar.git" "xxxxx"