### PR TITLE
Modify the dependency parsing to support dots in the repo name

### DIFF
--- a/carthage-verify
+++ b/carthage-verify
@@ -25,9 +25,10 @@ do
 
     # Handles:
     # - ReactiveCocoa/ReactiveSwift > ReactiveSwift
+    # - Auth0/JWTDecode.swift > JWTDecode.swift
     # - https://github.com/Carthage/Carthage.git > Carthage
     # - https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json > Mapbox-iOS-SDK
-    dependency=`basename ${array[0]} | awk -F'.' '{ print $1 }'`
+    dependency=`basename ${array[0]} | awk -F '.(git|json)' '{print $1}'`
 
     resolved_commitish=${array[1]}
 


### PR DESCRIPTION
It is possible for some repos to have a dot in their name.

https://github.com/auth0/JWTDecode.swift

The `awk` portion of the Carthage-verify script implicitly assumes that the dot in the dependency signifies a .git or .json extension.

This modifies the script so it will only strip `.git` and `.json` extensions from Cartfile.resolved entries.